### PR TITLE
Updating to load-js v1.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@driftory/viewer",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1050,9 +1050,9 @@
       }
     },
     "@dan503/load-js": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@dan503/load-js/-/load-js-1.0.2.tgz",
-      "integrity": "sha512-vuwXBHwhHf1sddbEHsDgmP//BKyOob1L6vs6DQZDpFgpT69ax3G3Wt06Fjtx4L+85RsCsqXvJ0btUBl+ytS4VQ=="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@dan503/load-js/-/load-js-1.0.3.tgz",
+      "integrity": "sha512-7CB23lPRVo+F/RbnzHYE5jvt9OZlQ3MIKqbk+2eoVazLl82miSMZ3RKzAR9z0KgZh9x+s7s//T9s2KeUW+8ysA=="
     },
     "@gulp-sourcemaps/identity-map": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/pixfabrik/driftory-viewer#readme",
   "dependencies": {
-    "@dan503/load-js": "^1.0.2",
+    "@dan503/load-js": "^1.0.3",
     "openseadragon": "^2.4.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@driftory/viewer",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "A viewer for comics created with https://www.driftory.com/",
   "main": "./dist/driftory.js",
   "scripts": {


### PR DESCRIPTION
v1.0.2 of load-js had a bug in it that was causing me issues when trying to re-open a closed Driftory comic.

Explained in these release notes:
https://github.com/Dan503/load-js/releases/tag/v1.0.3