### PR TITLE
Fixed the load-js issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@driftory/viewer",
-  "version": "0.1.4",
+  "version": "0.1.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1050,9 +1050,9 @@
       }
     },
     "@dan503/load-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@dan503/load-js/-/load-js-1.0.3.tgz",
-      "integrity": "sha512-7CB23lPRVo+F/RbnzHYE5jvt9OZlQ3MIKqbk+2eoVazLl82miSMZ3RKzAR9z0KgZh9x+s7s//T9s2KeUW+8ysA=="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@dan503/load-js/-/load-js-1.0.4.tgz",
+      "integrity": "sha512-j/P/RFpSwY2tl8a/Q6eWZzdVQJ71b+7Ocz4dFjtzmHPq3LR7qKrCaSqjPCUYwyen6yMC//32ht6GLiUoU1UhZg=="
     },
     "@gulp-sourcemaps/identity-map": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "gulp demo-site",
     "prettier": "prettier --write **/*.ts",
-    "prepublish": "gulp npm-bundle",
+    "prepublishOnly": "gulp npm-bundle",
     "postpublish": "gulp clean:npm-bundle",
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/pixfabrik/driftory-viewer#readme",
   "dependencies": {
-    "@dan503/load-js": "^1.0.3",
+    "@dan503/load-js": "^1.0.4",
     "openseadragon": "^2.4.2"
   },
   "devDependencies": {

--- a/src/library/driftory.ts
+++ b/src/library/driftory.ts
@@ -23,12 +23,12 @@ const osdPromise = new Promise((resolve, reject) => {
 });
 
 type Frame = any;
-type Container = any;
+type Container = HTMLElement;
 type OnFrameChange = (params: { frameIndex: number; isLastFrame: boolean }) => void;
 type OnComicLoad = (params: {}) => void;
 
 interface DriftoryArguments {
-  container: HTMLElement;
+  container: Container;
   onFrameChange?: OnFrameChange;
   onComicLoad?: OnComicLoad;
   prefixUrl?: string;
@@ -46,8 +46,8 @@ export default class Driftory {
 
   constructor(args: DriftoryArguments) {
     this.container = args.container;
-    this.onFrameChange = args.onFrameChange || function () {};
-    this.onComicLoad = args.onComicLoad || function () {};
+    this.onFrameChange = args.onFrameChange || function () { };
+    this.onComicLoad = args.onComicLoad || function () { };
 
     // Note: loadJs only loads the file once, even if called multiple times, and always makes sure
     // all of the callbacks are called.


### PR DESCRIPTION
- Updating to latest version of load-js.
- Changed "prepublish" to "prepublishOnly" (See [GitHub issue](https://github.com/npm/npm/issues/10074) for more details)

Since you haven't published the latest changes to npm yet, there is no need to bump the version number yet.